### PR TITLE
Timing information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ env:
   matrix:
   # - EMACS_VERSION=24.3
     - EMACS_VERSION=24.5
-    - EMACS_VERSION=snapshot
+    - EMACS_VERSION=25
+    - EMACS_VERSION=master
 before_install:
   # Configure $PATH: Executables are installed to $HOME/bin
   - export PATH="$HOME/bin:$PATH"
@@ -18,6 +19,6 @@ before_install:
   - do_make src
   - do_make lisp
   - do_make info
-  - do_make install
+  - do_make install | grep -E '^(make|[A-Z])'
 script:
   - emacs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: generic
+sudo: false
+env:
+  matrix:
+  # - EMACS_VERSION=24.3
+    - EMACS_VERSION=24.5
+    - EMACS_VERSION=snapshot
+  global:
+    - EMACSCONFFLAGS='--with-x-toolkit=no --without-x --without-all --with-xml2 CFLAGS= CXXFLAGS='
+before_install:
+  # Configure $PATH: Executables are installed to $HOME/bin
+  - export PATH="$HOME/bin:$PATH"
+  - . travis-steps.sh
+  - download
+  - unpack
+  - autogen
+  - configure
+  - do_make lib
+  - do_make lib-src
+  - do_make src
+  - do_make lisp
+  - do_make info
+  - do_make install
+script:
+  - emacs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ env:
   # - EMACS_VERSION=24.3
     - EMACS_VERSION=24.5
     - EMACS_VERSION=snapshot
-  global:
-    - EMACSCONFFLAGS='--with-x-toolkit=no --without-x --without-all --with-xml2 CFLAGS= CXXFLAGS='
 before_install:
   # Configure $PATH: Executables are installed to $HOME/bin
   - export PATH="$HOME/bin:$PATH"

--- a/travis-steps.sh
+++ b/travis-steps.sh
@@ -1,0 +1,32 @@
+# source me!
+
+if [ $EMACS_VERSION = 24.5 ] ; then
+download() {
+    curl -o "/tmp/emacs-${EMACS_VERSION}.tar.gz" "https://ftp.gnu.org/gnu/emacs/emacs-${EMACS_VERSION}.tar.gz"
+}
+unpack() {
+    tar xzf "/tmp/emacs-${EMACS_VERSION}.tar.gz" -C /tmp
+    mv /tmp/emacs-${EMACS_VERSION} /tmp/emacs
+}
+autogen() { :; }
+else
+download() {
+    git clone --depth=1 'http://git.sv.gnu.org/r/emacs.git' /tmp/emacs
+}
+unpack() { :; }
+autogen() {
+    cd /tmp/emacs && ./autogen.sh
+}
+fi
+
+configure() {
+    cd '/tmp/emacs' && ./configure --quiet --enable-silent-rules --prefix="${HOME}" ${EMACSCONFFLAGS}
+}
+
+do_make() {
+    make -j2 -C '/tmp/emacs' V=0 "$@"
+}
+
+# show definitions for log
+declare -f download unpack autogen configure do_make
+

--- a/travis-steps.sh
+++ b/travis-steps.sh
@@ -1,5 +1,7 @@
 # source me!
 
+EMACSCONFFLAGS=(--with-x-toolkit=no --without-x --without-all --with-xml2 CFLAGS='-O2 -march=native')
+
 if [ $EMACS_VERSION = 24.5 ] ; then
 download() {
     curl -o "/tmp/emacs-${EMACS_VERSION}.tar.gz" "https://ftp.gnu.org/gnu/emacs/emacs-${EMACS_VERSION}.tar.gz"
@@ -20,7 +22,7 @@ autogen() {
 fi
 
 configure() {
-    cd '/tmp/emacs' && ./configure --quiet --enable-silent-rules --prefix="${HOME}" ${EMACSCONFFLAGS}
+    cd '/tmp/emacs' && ./configure --quiet --enable-silent-rules --prefix="${HOME}" "${EMACSCONFFLAGS[@]}"
 }
 
 do_make() {
@@ -28,5 +30,6 @@ do_make() {
 }
 
 # show definitions for log
+printf ' (%s)' "${EMACSCONFFLAGS[@]}"
 declare -f download unpack autogen configure do_make
 

--- a/travis-steps.sh
+++ b/travis-steps.sh
@@ -2,24 +2,23 @@
 
 EMACSCONFFLAGS=(--with-x-toolkit=no --without-x --without-all --with-xml2 CFLAGS='-O2 -march=native')
 
-if [ $EMACS_VERSION = 24.5 ] ; then
+if [ $EMACS_VERSION = master ] ; then
+    revname=master
+else
+    revname=emacs-$EMACS_VERSION
+fi
+
 download() {
-    curl -o "/tmp/emacs-${EMACS_VERSION}.tar.gz" "https://ftp.gnu.org/gnu/emacs/emacs-${EMACS_VERSION}.tar.gz"
+    url=https://github.com/emacs-mirror/emacs/archive
+    curl -Lo "/tmp/emacs-${EMACS_VERSION}.tar.gz" "$url/$revname.tar.gz"
 }
 unpack() {
     tar xzf "/tmp/emacs-${EMACS_VERSION}.tar.gz" -C /tmp
-    mv /tmp/emacs-${EMACS_VERSION} /tmp/emacs
+    mv /tmp/emacs-$revname /tmp/emacs
 }
-autogen() { :; }
-else
-download() {
-    git clone --depth=1 'http://git.sv.gnu.org/r/emacs.git' /tmp/emacs
-}
-unpack() { :; }
 autogen() {
     cd /tmp/emacs && ./autogen.sh
 }
-fi
 
 configure() {
     cd '/tmp/emacs' && ./configure --quiet --enable-silent-rules --prefix="${HOME}" "${EMACSCONFFLAGS[@]}"


### PR DESCRIPTION
I create this pull request soley to have a list of links to the travis builds which have timing information (the travis build history also includes commits that are broken and therefore uninteresting, and no other github view has links to travis status (except branches which shows only the branch head status)).
